### PR TITLE
fix: 고정 확장자 토글 API 응답 타입 수정

### DIFF
--- a/src/main/java/com/flow/controller/ExtensionController.java
+++ b/src/main/java/com/flow/controller/ExtensionController.java
@@ -23,10 +23,9 @@ public class ExtensionController {
     }
 
     @PatchMapping("/fixed/{name}")
-    public ResponseEntity<Void> toggleFixed(@PathVariable String name,
-                                            @RequestBody FixedExtensionToggleRequest request) {
-        extensionService.toggleFixed(name, request.isBlocked());
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    public ResponseEntity<ExtensionResponse> toggleFixed(@PathVariable String name,
+                                                         @RequestBody FixedExtensionToggleRequest request) {
+        return ResponseEntity.status(HttpStatus.OK).body(extensionService.toggleFixed(name, request.isBlocked()));
     }
 
     @PostMapping("/custom")

--- a/src/main/java/com/flow/service/ExtensionService.java
+++ b/src/main/java/com/flow/service/ExtensionService.java
@@ -36,10 +36,11 @@ public class ExtensionService {
         return new ExtensionResponse(fixed, custom);
     }
 
-    public void toggleFixed(String name, boolean blocked) {
+    public ExtensionResponse toggleFixed(String name, boolean blocked) {
         fixedExtensionRepository.findById(name)
                 .orElseThrow(() -> new ExtensionException("존재하지 않는 고정 확장자입니다: " + name))
                 .updateBlocked(blocked);
+        return getAll();
     }
 
     public ExtensionResponse addCustom(String rawName) {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -107,6 +107,10 @@
                 method: 'PATCH',
                 contentType: 'application/json',
                 data: JSON.stringify({ blocked: blocked }),
+                success: function(data) {
+                    renderFixed(data.fixed);
+                    renderCustom(data.custom);
+                },
                 error: function(xhr) {
                     if (xhr.status >= 500 || xhr.status === 0) {
                         showModal();


### PR DESCRIPTION
## 문제                                                  
PATCH 응답이 void라 다른 API(POST, DELETE)와 불일치 프론트엔드가 토글 후 별도 GET 요청 없이 화면 갱신 불가   
                                                         
## 해결
반환 타입을 ExtensionResponse(200)로 변경하여 응답 통일

이슈  #15 